### PR TITLE
Fix site-url in _quarto.yml

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -8,7 +8,7 @@ project:
 website:
   page-navigation: true
   title: "Template for training resources in Python"
-  site-url: "https://github.com/AIML4OS/AIML4OS-template-quarto-python"
+  site-url: "https://AIML4OS.github.io/AIML4OS-template-quarto-python/"
   repo-url: "https://github.com/AIML4OS/AIML4OS-template-quarto-python"
   repo-actions: [edit, source, issue]
   sidebar:


### PR DESCRIPTION
Fix site-url in _quarto.yml with the same URL described in the startup guide and adapted for the AIML4OS repository.